### PR TITLE
Fix #7 Only show title/description if they exist, and ...

### DIFF
--- a/tpl/Ajax/respopup.tpl
+++ b/tpl/Ajax/respopup.tpl
@@ -36,6 +36,7 @@ along with Booked Scheduler.  If not, see <http://www.gnu.org/licenses/>.
 
 	{capture "title"}
 	{if !$hideDetails}
+		{* Changed to remove "(no title)" output *}
 		{if $title neq ''}<div class="title">{$title}</div>{/if}
 	{/if}
 	{/capture}
@@ -52,8 +53,13 @@ along with Booked Scheduler.  If not, see <http://www.gnu.org/licenses/>.
 	{/capture}
 	{$formatter->Add('resources', $smarty.capture.resources)}
 
+	{* Removed "Participants" output *}
+
+	{* Removed "Accessories" output *}
+
 	{capture "description"}
 	{if !$hideDetails}
+		{* Changed to remove "(no description)" output *}
 		{if $summary neq ''}<div class="summary">{$summary|truncate:300:"..."|nl2br}</div>{/if}
 	{/if}
 	{/capture}

--- a/tpl/Ajax/respopup.tpl
+++ b/tpl/Ajax/respopup.tpl
@@ -36,7 +36,7 @@ along with Booked Scheduler.  If not, see <http://www.gnu.org/licenses/>.
 
 	{capture "title"}
 	{if !$hideDetails}
-		<div class="title">{if $title neq ''}{$title}{else}{translate key=NoTitleLabel}{/if}</div>
+		{if $title neq ''}<div class="title">{$title}</div>{/if}
 	{/if}
 	{/capture}
 	{$formatter->Add('title', $smarty.capture.title)}
@@ -52,37 +52,9 @@ along with Booked Scheduler.  If not, see <http://www.gnu.org/licenses/>.
 	{/capture}
 	{$formatter->Add('resources', $smarty.capture.resources)}
 
-	{capture "participants"}
-	{if !$hideUserInfo && !$hideDetails}
-	<div class="users">
-	{translate key="Participants"} ({$participants|@count}):
-	{foreach from=$participants item=user name=participant_loop}
-		{if !$user->IsOwner()}
-			{fullname first=$user->FirstName last=$user->LastName}
-		{/if}
-		{if !$smarty.foreach.participant_loop.last}, {/if}
-	{/foreach}
-	</div>
-	{/if}
-	{/capture}
-	{$formatter->Add('participants', $smarty.capture.participants)}
-
-	{capture "accessories"}
-	{if !$hideDetails}
-		<div class="accessories">
-		{translate key="Accessories"} ({$accessories|@count}):
-		{foreach from=$accessories item=accessory name=accessory_loop}
-			{$accessory->Name} ({$accessory->QuantityReserved})
-			{if !$smarty.foreach.accessory_loop.last}, {/if}
-		{/foreach}
-		</div>
-	{/if}
-	{/capture}
-	{$formatter->Add('accessories', $smarty.capture.accessories)}
-
 	{capture "description"}
 	{if !$hideDetails}
-		<div class="summary">{if $summary neq ''}{$summary|truncate:300:"..."|nl2br}{else}{translate key=NoDescriptionLabel}{/if}</div>
+		{if $summary neq ''}<div class="summary">{$summary|truncate:300:"..."|nl2br}</div>{/if}
 	{/if}
 	{/capture}
 	{$formatter->Add('description', $smarty.capture.description)}


### PR DESCRIPTION
… don't output unused participants and accessories fields

The above refers to the tooltip text over a reserved room/timeslot.